### PR TITLE
Detect existing PDF shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF Editing Demo
 
-This is a simple web application that allows uploading a PDF and viewing it in the browser. A **Scan** button overlays the pages with editable shapes using [fabric.js](http://fabricjs.com/). The actual detection of PDF elements is not implemented, but the framework is provided for experimentation.
+This is a simple web application that allows uploading a PDF and viewing it in the browser. Pressing **Scan** analyses each page and overlays editable shapes corresponding to rectangles or circles found in the PDF using [fabric.js](http://fabricjs.com/).
 
 ## Setup
 
@@ -23,7 +23,7 @@ This is a simple web application that allows uploading a PDF and viewing it in t
 
 1. Open `index.html` in a modern browser.
 2. Select a PDF file using the upload input.
-3. Click **Scan** to enable editing. Placeholder shapes are added for demonstration.
+3. Click **Scan** to enable editing. Detected rectangles and circles become editable on the page.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- parse `getOperatorList` results to find rectangles and circles
- overlay detected shapes as editable fabric.js objects
- update documentation for scanning existing shapes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fb1018c7c83289542100fcf90db77