### PR TITLE
Improve scan overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# tester
+# PDF Editing Demo
+
+This is a simple web application that allows uploading a PDF and viewing it in the browser. Clicking **Scan** overlays each page with editable shapes using [fabric.js](http://fabricjs.com/). The app highlights detected text boxes as movable rectangles. True element detection for diagrams is not implemented, but the framework is provided for experimentation.
+
+## Usage
+
+1. Open `index.html` in a modern browser.
+2. Select a PDF file using the upload input.
+3. Click **Scan** to enable editing. Detected text areas are highlighted and can be resized or moved.
+
+## Development
+
+This project uses CDN builds of `pdf.js` and `fabric.js`.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,83 @@
+const fileInput = document.getElementById('file-input');
+const pdfViewer = document.getElementById('pdf-viewer');
+const scanButton = document.getElementById('scan-button');
+let pdfDoc = null;
+
+fileInput.addEventListener('change', async (e) => {
+    const file = e.target.files[0];
+    if (file) {
+        const url = URL.createObjectURL(file);
+        pdfDoc = await pdfjsLib.getDocument(url).promise;
+        renderPDF();
+    }
+});
+
+async function renderPDF() {
+    pdfViewer.innerHTML = '';
+    for (let pageNum = 1; pageNum <= pdfDoc.numPages; pageNum++) {
+        const page = await pdfDoc.getPage(pageNum);
+        const viewport = page.getViewport({ scale: 1.5 });
+
+        const container = document.createElement('div');
+        container.className = 'page-container';
+
+        const canvas = document.createElement('canvas');
+        canvas.className = 'pdf-canvas';
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+
+        const overlay = document.createElement('canvas');
+        overlay.className = 'overlay-canvas';
+        overlay.width = viewport.width;
+        overlay.height = viewport.height;
+
+        const context = canvas.getContext('2d');
+        await page.render({ canvasContext: context, viewport }).promise;
+
+        container.appendChild(canvas);
+        container.appendChild(overlay);
+        pdfViewer.appendChild(container);
+    }
+}
+
+scanButton.addEventListener('click', () => {
+    if (!pdfDoc) return;
+    enableEditing();
+});
+
+async function enableEditing() {
+    const containers = document.querySelectorAll('.page-container');
+
+    const loading = document.createElement('div');
+    loading.id = 'loading';
+    loading.textContent = 'Scanning...';
+    document.body.appendChild(loading);
+
+    for (let i = 0; i < containers.length; i++) {
+        const overlay = containers[i].querySelector('.overlay-canvas');
+        const fabricCanvas = new fabric.Canvas(overlay, { selection: true });
+
+        const page = await pdfDoc.getPage(i + 1);
+        const viewport = page.getViewport({ scale: 1.5 });
+        const textContent = await page.getTextContent();
+
+        textContent.items.forEach((item) => {
+            const tx = pdfjsLib.Util.transform(viewport.transform, item.transform);
+            const x = tx[4];
+            const y = tx[5];
+            const height = Math.hypot(tx[2], tx[3]);
+            const rect = new fabric.Rect({
+                left: x,
+                top: y - height,
+                width: item.width * viewport.scale,
+                height,
+                fill: 'rgba(0, 0, 255, 0.2)',
+                stroke: 'blue',
+                selectable: true,
+            });
+            fabricCanvas.add(rect);
+        });
+    }
+
+    loading.remove();
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PDF Editor</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.3.0/fabric.min.js"></script>
+</head>
+<body>
+    <h1>PDF Viewer</h1>
+    <input type="file" id="file-input" accept="application/pdf" />
+    <button id="scan-button">Scan</button>
+    <div id="pdf-viewer"></div>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,37 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+#pdf-viewer {
+    margin-top: 20px;
+}
+
+.page-canvas {
+    border: 1px solid #ccc;
+    margin-bottom: 10px;
+    display: block;
+}
+
+.page-container {
+    position: relative;
+    display: inline-block;
+}
+
+.overlay-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: auto;
+}
+
+#loading {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    background: #333;
+    color: #fff;
+    padding: 4px 8px;
+    border-radius: 3px;
+    z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- show scanning overlay and highlight text boxes when scanning
- add overlay canvases on top of PDF pages instead of replacing them
- update README usage instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f7e9b36a48328892f78e0cdd941ea