### PR TITLE
Release object URL after PDF render

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,12 +12,17 @@ fileInput.addEventListener('change', async (e) => {
     const file = e.target.files[0];
     if (file) {
         const url = URL.createObjectURL(file);
-        pdfDoc = await pdfjsLib.getDocument(url).promise;
-        currentPage = 1;
-        renderPage(currentPage);
-        updatePageInfo();
+        await renderPDF(url);
+        URL.revokeObjectURL(url);
     }
 });
+
+async function renderPDF(url) {
+    pdfDoc = await pdfjsLib.getDocument(url).promise;
+    currentPage = 1;
+    await renderPage(currentPage);
+    updatePageInfo();
+}
 
 async function renderPage(pageNum) {
     pdfViewer.innerHTML = '';


### PR DESCRIPTION
## Summary
- factor PDF loading into new `renderPDF` helper
- release object URL after rendering completes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fc24148508328835487a2636b89a5