### PR TITLE
Release object URL after PDF render

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF Editing Demo
 
-This is a simple web application that allows uploading a PDF and viewing it in the browser. You can navigate the document one page at a time and press **Scan This Page** to analyse the current page. Detected rectangles and circles become editable using [fabric.js](http://fabricjs.com/).
+This is a simple web application that allows uploading a PDF and viewing it in the browser. You can navigate the document one page at a time and press **Scan This Page** to highlight detected rectangles and circles using [fabric.js](http://fabricjs.com/). Text areas appear as movable rectangles. Diagram detection is not fully implemented yet, but the framework is provided for experimentation.
 
 ## Setup
 
@@ -14,17 +14,16 @@ This is a simple web application that allows uploading a PDF and viewing it in t
    ```
 3. **Open the project**
    - Either open `index.html` directly in a modern browser, **or**
-   - Start a simple HTTP server (for example with Python) and navigate to `http://localhost:8000`:
+   - Start a simple HTTP server and navigate to `http://localhost:8000`:
      ```bash
      python3 -m http.server
      ```
 
 ## Usage
 
-1. Open `index.html` in a modern browser.
-2. Select a PDF file using the upload input.
-3. Use **Prev** and **Next** to switch pages.
-4. Click **Scan This Page** to enable editing for the page in view. Detected rectangles and circles become editable.
+1. Select a PDF file using the upload input.
+2. Use **Prev** and **Next** to switch pages.
+3. Click **Scan This Page** to enable editing for the page in view. Detected rectangles and circles become editable.
 
 ## Development
 

--- a/app.js
+++ b/app.js
@@ -12,12 +12,17 @@ fileInput.addEventListener('change', async (e) => {
     const file = e.target.files[0];
     if (file) {
         const url = URL.createObjectURL(file);
-        pdfDoc = await pdfjsLib.getDocument(url).promise;
-        currentPage = 1;
-        renderPage(currentPage);
-        updatePageInfo();
+        await renderPDF(url);
+        URL.revokeObjectURL(url);
     }
 });
+
+async function renderPDF(url) {
+    pdfDoc = await pdfjsLib.getDocument(url).promise;
+    currentPage = 1;
+    await renderPage(currentPage);
+    updatePageInfo();
+}
 
 async function renderPage(pageNum) {
     pdfViewer.innerHTML = '';


### PR DESCRIPTION
## Summary
- factor PDF loading into new `renderPDF` helper
- release object URL after rendering completes
- resolve merge conflict in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fc24148508328835487a2636b89a5